### PR TITLE
snapshots for ops4j artifacts

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,6 +17,17 @@
   <properties>
     <paxexamversion>2.1.1-SNAPSHOT</paxexamversion>
   </properties>
+
+   <repositories>
+    <repository>
+      <id>ops4jsnapshots</id>
+      <url>https://oss.sonatype.org/content/groups/ops4j/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>
@@ -60,7 +71,14 @@
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-link-mvn</artifactId>
+      <artifactId>pax-exam-link-assembly</artifactId>
+      <version>${paxexamversion}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-rbc</artifactId>
       <version>${paxexamversion}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
- added ops4j snapshot repo to pom.xml
- added pax-exam-container-rbc to pom. This is a runtime artifact that is loaded usually automatically.
  Since this artifact is part of pax exam, it also must come from the snapshot repo.
  It requires some more explanation, but when using NativeContainer you don't get all the pax runner goodies (like repository() option in @Configuration). As a workaround, we add the artifact to the pom, so maven loads it at resolve time and put it into the local maven cache.
  From there, the runtime stuff in Exam (or better, Pax URL) can locate it without knowing of the ops4j snapshot repo in the first place.
  (too tired now, not sure if this is even understandable).
  Actually, it works.
